### PR TITLE
Change form fields from hidden to text for phoenix liveview testing ease of use

### DIFF
--- a/lib/live_select/component.html.heex
+++ b/lib/live_select/component.html.heex
@@ -63,16 +63,17 @@
     <% end %>
   </div>
   <%= if @mode == :single do %>
-    <%= hidden_input(@field.form, @field.field,
+    <%= text_input(@field.form, @field.field,
       disabled: @disabled,
-      class: "single-mode",
+      class: "single-mode hidden",
       value: value(@selection)
     ) %>
   <% else %>
     <!-- TODO: the stuff below could be replaced with a single hidden, readonly multiselect, but updates don't quite work. So we resort to hidden inputs for now -->
     <%= if Enum.empty?(@selection) do %>
       <input
-        type="hidden"
+        type="text"
+        class="hidden"
         name={"#{@field.form.name}[#{@field.field}_empty_selection]"}
         id={"#{@field.id}_empty_selection"}
         disabled={@disabled}
@@ -81,7 +82,8 @@
     <% end %>
     <%= for {value, idx} <- values(@selection) |> Enum.with_index() do %>
       <input
-        type="hidden"
+        type="text"
+        class="hidden"
         name={@field.name <> "[]"}
         id={@field.id <> "_#{idx}"}
         disabled={@disabled}


### PR DESCRIPTION
I can't use the normal liveview testing functions when using this library because of the hidden inputs. I would have to modify all my tests to populate the form field in a different way when using live_select. If we make the form fields type text and add a hidden class to them, then the tests will work without modification.

### Example, I have a form that is using the live_select component for an org_id on a user:

#### In current library state with hidden form fields:
```
create_attrs = %{
  org_id: 1,
  first_name: "John",
  last_name: "Doe",
  email: "john.doe@email.com",
  phone_number: "1234567890"
}

assert index_live
       |> form("#user-form", user: Map.delete(create_attrs, :org_id))
       |> render_submit(%{user: %{org_id: create_attrs[:org_id]}})
```

#### Using my PR, we can keep the tests the way they come using phoenix generators:
```
create_attrs = %{
  org_id: 1,
  first_name: "John",
  last_name: "Doe",
  email: "john.doe@email.com",
  phone_number: "1234567890"
}

assert index_live
       |> form("#user-form", user: create_attrs)
       |> render_submit()
```
